### PR TITLE
ci: Use step-security maintained actions

### DIFF
--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       #----------------------------------------------
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
       #----------------------------------------------
       #       Get changed plugins
       #----------------------------------------------

--- a/.github/workflows/pr-linting-and-unit-tests.yaml
+++ b/.github/workflows/pr-linting-and-unit-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       #----------------------------------------------
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
       #----------------------------------------------
       #       Get changed plugins
       #----------------------------------------------


### PR DESCRIPTION
**Description**:

Updates tj-actions/changed-files to use step-security maintained version

**Related Issue(s)**:

Fixes #18
